### PR TITLE
Update number of hours that recommendations are cached and other misc. copyedits

### DIFF
--- a/pages/Documents/ConversationalAI/ConversationAssist/RecommendationSources/configuring-settings.md
+++ b/pages/Documents/ConversationalAI/ConversationAssist/RecommendationSources/configuring-settings.md
@@ -15,7 +15,7 @@ The **Settings** page in Conversation Assist contains settings that are shared b
 
 This setting applies to all recommendation sources.
 
-<img width="600" src="img/agentassist/settings_general2.png" alt="">
+<img width="600" alt="Suspend setting" src="img/agentassist/settings_general2.png" alt="">
 
 When this setting is on (blinking green), Conversation Assist recommends bots and answers inline in conversations. Click the toggle to suspend or resume recommendations globally.
 
@@ -23,7 +23,7 @@ When this setting is on (blinking green), Conversation Assist recommends bots an
 
 This setting applies to all recommendation sources.
 
-<img width="600" src="img/agentassist/settings_general.png" alt="">
+<img width="600" alt="Max number of recommendations setting" src="img/agentassist/settings_general.png" alt="">
 
 Set the maximum number of recommendations (bot and answer) that Conversation Assist offers at one time. The default value is 3.
 
@@ -31,7 +31,7 @@ Set the maximum number of recommendations (bot and answer) that Conversation Ass
 
 Set the **Answer confidence** if you’re using knowledge bases as recommendation sources.
 
-<img width="400" src="img/agentassist/settings_answerconfidence.png" alt="">
+<img width="400" alt="Answer confidence setting" src="img/agentassist/settings_answerconfidence.png" alt="">
 
 The consumer’s intent will be matched to the articles in the knowledge bases, where each match is assigned a score indicating the system’s confidence in the match. Select the minimum confidence score that an article must have for it to be offered as a recommended answer that can be sent to the consumer.
 
@@ -41,7 +41,7 @@ The higher the score, the more relevant the recommendations. To offer more recom
 
 Set the **Bot confidence** if you’re using bots as recommendation sources.
 
-<img width="400" src="img/agentassist/settings_botconfidence.png" alt="">
+<img width="400" alt="Bot confidence setting" src="img/agentassist/settings_botconfidence.png" alt="">
 
 The consumer’s intent will be matched to the bots, where each match is assigned a score indicating the system’s confidence in the match. Select the minimum score that a bot must have for it to be offered as a recommended bot that can handle the conversation.
 
@@ -51,4 +51,4 @@ The higher the score, the more relevant the recommendations. To offer more recom
 
 Customize the **bot messages** if you’re using bots as recommendation sources. The messages are sent to the consumer when the bot is added to and removed from a conversation. They help consumers to understand when a bot is involved in a conversation.
 
-<img width="800" src="img/agentassist/settings_botmessages.png" alt="">
+<img width="800" alt="Bot messages settings" src="img/agentassist/settings_botmessages.png" alt="">

--- a/pages/Documents/ConversationalAI/ConversationAssist/RecommendationSources/setting-up-bots.md
+++ b/pages/Documents/ConversationalAI/ConversationAssist/RecommendationSources/setting-up-bots.md
@@ -32,7 +32,7 @@ To set up Conversation Assist to recommend bots, you need some prerequisite know
 
 If you intend to build your bots using Conversation Builder, you must be able to use [Conversation Builder](conversation-builder-overview.html) to create and deploy a bot. And if, for utterance matching, you’ll be using intents instead of patterns, you must also be able to use [Intent Manager](intent-manager-overview.html) to create a domain and the intents. For exposure to these applications and tasks, we recommend that you complete the [Getting Started with Bot Building](tutorials-guides-getting-started-with-bot-building-overview.html) tutorial series.
 
-If you intend to build your bots using a third-party application, see [here](third-party-bots-getting-started.html) for more information.
+If you intend to build your bots using a third-party application, see the [Getting Started info](third-party-bots-getting-started.html).
 
 ### High-level workflow
 1. In **Conversation Builder** or the third-party application, create the bots.
@@ -42,9 +42,9 @@ If you intend to build your bots using a third-party application, see [here](thi
 5. In **Conversation Assist**, configure relevant settings.
 
 ### Step 1: Create the bots
-[Access Conversation Builder](conversation-builder-overview.html#access-conversation-builder) and create at least one bot. For help, see the tutorial [here](tutorials-guides-getting-started-with-bot-building-overview.html). 
+[Access Conversation Builder](conversation-builder-overview.html#access-conversation-builder) and create at least one bot. For help, try [the tutorial](tutorials-guides-getting-started-with-bot-building-overview.html). 
 
-For help with creating a third-party bot, see [here](third-party-bots-getting-started.html) for info.
+For help with creating a third-party bot, see the [Getting Started info](third-party-bots-getting-started.html).
 
 ### Step 2: Create the bot users
 Configure Conversational Cloud by creating a bot user for each bot. This is illustrated in the Conversation Assist [tutorial](tutorials-guides-using-conversation-assist-overview.html). Specify a bot user name that make sense for your use case.
@@ -58,19 +58,19 @@ To connect a Google Dialogflow or IBM Watson bot to LivePerson’s Conversationa
 
 1. [Access Conversation Assist](conversation-assist-overview.html#access-conversation-assist), and click **Recommendation Sources** from the menu at the top.
 2. Click the **Bots** tab.
-3. Click <img class="inlineimage" style="width:25px" src="img/agentassist/icon_refresh.png"> over on the right. This fetches the available bots. Available bots include those you’ve deployed and started (i.e., they’re valid bots that can serve a conversation). You should see all of the bots that you’ve created (both public and private) and other public bots within your organization.
+3. Click <img class="inlineimage" style="width:25px" alt="Sync button" src="img/agentassist/icon_refresh.png"> over on the right. This fetches the available bots. Available bots include those you’ve deployed and started (i.e., they’re valid bots that can serve a conversation). You should see all of the bots that you’ve created (both public and private) and other public bots within your organization.
 
-    <img width="700" src="img/agentassist/configbot1.png">
+    <img width="700" alt="Bots tab showing a list of bots that are turned on but one bot that is turned off"src="img/agentassist/configbot1.png">
 
-4. Verify that your bot is displayed. If it isn't, consult the troubleshooting information [here](conversation-assist-troubleshooting.html).
+4. Verify that your bot is displayed. If it isn't, consult the [troubleshooting info](conversation-assist-troubleshooting.html).
 
     Your bot doesn't have any assigned skills yet, so its **Status** is initially set to "Off." For the bot to be recommended in conversations, you must assign one or more skills **and** change the **Status**.
 
 5. Assign one or more skills to the bot:
-    1. Beside the bot, click the <img style="width:25px" src="img/agentassist/icon_managesource.png"> (Manage source) icon.
+    1. Beside the bot, click the <img style="width:25px" alt="Pencil icon" src="img/agentassist/icon_managesource.png"> (Manage source) icon.
     2. In the **Manage recommendation source** dialog, change the **Status** to "ON," and add one or more skills.
 
-        <img width="700" src="img/agentassist/configbot2.png">
+        <img width="700" alt="Manage recommendation source window with options for turning the bot on and off and for assigning skills" src="img/agentassist/configbot2.png">
 
     3. Click **Save**.
 6. Repeat this process for additional bots as needed.
@@ -79,7 +79,7 @@ To connect a Google Dialogflow or IBM Watson bot to LivePerson’s Conversationa
 
     In our example below, for the agent to be recommended the Ordering Bot, the agent must pick up a conversation that was routed to either the “Support” or “Ordering” skills. 
 
-    <img width="700" src="img/agentassist/configbot3.png">
+    <img width="700" alt="Bots tab with all bots now turned on" src="img/agentassist/configbot3.png">
 
     Keep in mind that a conversation is routed to the skills assigned to the campaign’s engagement.
 

--- a/pages/Documents/ConversationalAI/ConversationAssist/RecommendationSources/setting-up-knowledge-bases.md
+++ b/pages/Documents/ConversationalAI/ConversationAssist/RecommendationSources/setting-up-knowledge-bases.md
@@ -63,19 +63,19 @@ At this point, use KnowledgeAI to verify that the desired articles are active. T
 
     The **Knowledge Bases** tab is displayed by default.
 
-2. Click <img class="inlineimage" style="width:25px" src="img/agentassist/icon_refresh.png" alt=""> over on the right. This syncs with KnowledgAI and shows you the available knowledge bases.
+2. Click <img class="inlineimage" alt="Sync button" style="width:25px" src="img/agentassist/icon_refresh.png" alt=""> over on the right. This syncs with KnowledgAI and shows you the available knowledge bases.
 
-    <img width="700" src="img/agentassist/configkb1.png" alt="">
+    <img width="700" alt="Knowledge Bases tab with two knowledge bases that are both set to off" src="img/agentassist/configkb1.png" alt="">
 
-3. Verify that your knowledge base is displayed. If it isn't, consult the troubleshooting information [here](conversation-assist-troubleshooting.html).
+3. Verify that your knowledge base is displayed. If it isn't, consult the [troubleshooting info](conversation-assist-troubleshooting.html).
 
     Your knowledge base doesn't have any assigned skills yet, so its **Status** is initially set to "Off." For the articles therein to be recommended as answers, you must assign one or more skills **and** change the **Status**.
 
 4. Assign one or more skills to the knowledge base:
-    1. Beside the knowledge base, click the <img style="width:25px" src="img/agentassist/icon_managesource.png" alt=""> (Manage source) icon.
+    1. Beside the knowledge base, click the <img style="width:25px" alt="Pencil icon" src="img/agentassist/icon_managesource.png" alt=""> (Manage source) icon.
     2. In the **Manage recommendation source** dialog, change the **Status** to "ON," and add one or more skills.
 
-        <img width="700" src="img/agentassist/configkb2.png" alt="">
+        <img width="700" alt="Manage recommendation source window, with options for turning on and off and for assigning skills" src="img/agentassist/configkb2.png" alt="">
 
     3. Click **Save**.
 5. Repeat this process for additional knowledge bases as needed.
@@ -84,7 +84,7 @@ At this point, use KnowledgeAI to verify that the desired articles are active. T
 
     In our example below, for the agent to be offered an answer from the Order Questions knowledge base, the agent must pick up a conversation that was routed to either the “Support” or “Ordering” skills.
 
-    <img width="700" src="img/agentassist/configkb3.png" alt="">
+    <img width="700" alt="Knowledge Bases tab with one knowledge base still off but one knowledge base now on" src="img/agentassist/configkb3.png" alt="">
 
     Keep in mind that a conversation is routed to the skills assigned to the campaign’s engagement.
 

--- a/pages/Documents/ConversationalAI/ConversationAssist/agent-experience.md
+++ b/pages/Documents/ConversationalAI/ConversationAssist/agent-experience.md
@@ -11,21 +11,22 @@ indicator: messaging
 ---
 
 {: .important}
-No bot or answer recommendations are made when the consumer’s message is 3 words or fewer, or when the consumer’s message is non-intentful (e.g., a greeting or other phrase like, “Are you still there” or “Give me a minute,” and so on).<br><br>All recommendations that are made based on consumer utterances are cached for 3 hours. Keep this in mind as you update your bots and knowledge bases. If things look stale during testing, try using a slightly different utterance.
+When evaluating the agent experience, keep in mind the [FAQs](conversation-assist-faqs.html).
 
-**Tip:** To train your agents, you can start by enabling recommendations for a single skill.
+### Tip
+To train your agents, start by enabling recommendations for a single skill.
 
 ### Use a recommended bot or article
 
 In Conversational Cloud, bot and article recommendations are displayed inline within the conversation.
 
-<img width="550" src="img/agentassist/use_recs.png" alt="">
+<img width="550" alt="Two recommendations being offered to the agent inline in the conversation" src="img/agentassist/use_recs.png" alt="">
 
 **To use a recommended bot**
 
 * Click **Delegate** to join a bot to the conversation, so the bot takes over. You stay in the conversation, so you can monitor the bot’s progress and remove the bot if needed.
 
-    <img width="550" src="img/agentassist/use_bot.png" alt="">
+    <img width="550" alt="The conversation flow when a bot is joined to the conversation" src="img/agentassist/use_bot.png" alt="">
 
     **Tip:** As shown in the image above, a system message announces when the bot joins the conversation. You can [customize this message](conversation-assist-recommendation-sources-configuring-settings.html#bot-messages).
 
@@ -33,8 +34,8 @@ In Conversational Cloud, bot and article recommendations are displayed inline wi
 
 * Click **Use Answer** to copy the article’s text to the agent’s text input area. You can edit the text before sending it to the consumer.
 
-    <img width="550" src="img/agentassist/use_article.png" alt="">
-    <img width="550" src="img/agentassist/use_article2.png" alt="">
+    <img width="550" alt="Use answer button for using a recommended answer" src="img/agentassist/use_article.png" alt="">
+    <img width="550" alt="The conversation flow after a recommended answer has been used" src="img/agentassist/use_article2.png" alt="">
 
 ### Remove or replace the current bot
 
@@ -43,8 +44,8 @@ After you have joined a bot to a conversation, you can remove or replace it if d
 * To remove the current bot, click **Remove bot** at the top of the messaging panel. The agent can then take over.
 * To replace the current bot, click **Replace bot** beside the bot you want to substitute into the conversation. The selected bot joins the conversation, taking over for the previous bot. (Only one bot can be joined to a conversation at a time.)
 
-    <img width="550" src="img/agentassist/remove_replace_bot.png" alt="">
+    <img width="550" alt="Remove bot and Replace bot options that are available when a bot is a part of the conversation" src="img/agentassist/remove_replace_bot.png" alt="">
 
 ### Notify the agent when the bot has finished
 
-If you’re recommending bots to your agents, it can be a challenge for the agent to know when the bot has finished its work. The agent must check back repeatedly on the bot’s progress. To solve this, the bot can send a [private message](conversation-builder-interactions-statements.html#private-message) when it’s finished handling the consumer’s request. The private message can tell the agent what action has been taken, and let them know that it’s time for them to rejoin the conservation to close things out with the consumer. More on private messages [here](conversation-builder-interactions-statements.html#private-message).
+If you’re recommending bots to your agents, it can be a challenge for the agent to know when the bot has finished its work. The agent must check back repeatedly on the bot’s progress. To solve this, the bot can send a [private message](conversation-builder-interactions-statements.html#private-message) when it’s finished handling the consumer’s request. The private message can tell the agent what action has been taken, and let them know that it’s time for them to rejoin the conservation to close things out with the consumer.

--- a/pages/Documents/ConversationalAI/ConversationAssist/faqs.md
+++ b/pages/Documents/ConversationalAI/ConversationAssist/faqs.md
@@ -23,13 +23,13 @@ Yes, you can do this per recommendation source. To do this:
 1. [Access Conversation Assist](conversation-assist-overview.html#access-conversation-assist).
 2. Click **Recommendations Sources** from the menu at the top.
 3. Click the **Knowledge Bases** tab or the **Bots** tab, as appropriate.
-4. Beside the source, click the <img style="width:25px" src="img/agentassist/icon_managesource.png"> (Manage source) icon.
+4. Beside the source, click the <img style="width:25px" alt="Pencil icon" src="img/agentassist/icon_managesource.png"> (Manage source) icon.
 5. In the **Manage recommendation source** dialog, change the Status to “OFF.”
 6. Click **Save**.
 
 #### Why aren’t my knowledge bases discovered?
 
-There are a few reasons why this might be the case. For more, see [here](conversation-assist-troubleshooting.html#knowledge-bases) in *Troubleshooting*.
+There are a few reasons why this might be the case. For more, see our [troubleshooting info](conversation-assist-troubleshooting.html#knowledge-bases).
 
 #### Why aren’t my knowledge base answers formatted?
 
@@ -46,7 +46,7 @@ Currently, the denominator is incorrect. It reflects only the recommendations th
 To make recommendations, Conversation Assist analyzes the available bots and knowledge base articles that match the consumer’s intent, and it finds the best ones. The recommendations are made by choosing those ranked highest by relevance score.
 
 {: .important}
-No bot or answer recommendations are made when the consumer’s message is 3 words or fewer, or when the consumer’s message is non-intentful (e.g., a greeting or other phrase like, “Are you still there” or “Give me a minute,” and so on).<br><br>All recommendations that are made based on consumer utterances are cached for 3 hours. Keep this in mind as you update your bots and knowledge bases. If things look stale during testing, try using a slightly different utterance.
+No bot or answer recommendations are made when the consumer’s message is 3 words or fewer, or when the consumer’s message is non-intentful (e.g., a greeting or other phrase like, “Are you still there” or “Give me a minute,” and so on).<br><br>All recommendations that are made based on consumer utterances are cached for 24 hours. Keep this in mind as you update your bots and knowledge bases. If things look stale during testing, try using a slightly different utterance.
 
 The rules for how the recommendations are made and ordered are as follows:
 

--- a/pages/Documents/ConversationalAI/ConversationAssist/overview.md
+++ b/pages/Documents/ConversationalAI/ConversationAssist/overview.md
@@ -24,7 +24,7 @@ Did you know that LivePerson has a Conversational AI forum for builders? [Check 
 
 Conversation Assist offers recommended bots and answers to your human agents inline in their conversations with consumers.
 
-<img width="400" src="img/agentassist/example2.gif" align="left" style="margin: 0 25px 0 0;">
+<img width="400" alt="Animation showing inline recommendations being offered" src="img/agentassist/example2.gif" align="left" style="margin: 0 25px 0 0;">
 
 When your agents take advantage of these just-in-time recommendations, they become more efficient and save time. What's more, their conversational outcomes are improved and more consistent. Conversation Assist can even help to reduce the time to onboard new agents.
 
@@ -32,7 +32,7 @@ You can set up bot and answer recommendations in just a few clicks.
 
 On the **Home** page of Conversation Assist, you'll find a dashboard of rich analytics, which you can use to continuously monitor and tune recommendation performance. Use this valuable data to understanding the impact that your solution is having on your agent operations.
 
-<img width="800" src="img/agentassist/dashboard.png" alt="">
+<img width="800" alt="View of the top of the Conversation Assist dashboard" src="img/agentassist/dashboard.png" alt="">
 
 {: .important}
 Just getting started? Complete the [Using Conversation Assist](tutorials-guides-using-conversation-assist-overview.html) tutorial.
@@ -41,7 +41,7 @@ Just getting started? Complete the [Using Conversation Assist](tutorials-guides-
 
 Within a messaging conversation, Conversation Assist recommends bots and answers based on the intent that’s detected in the consumer’s message. The recommendations are presented in real time, inline within the conversation.
 
-<img width="550" src="img/agentassist/example.png" alt="">
+<img width="550" alt="View of the agent workspace with two recommendations being offered to the agent" src="img/agentassist/example.png" alt="">
 
 When offered a recommended answer, the agent can send it to the consumer. The agent can optionally modify it before sending it.
 
@@ -67,5 +67,5 @@ Recommendation sources include knowledge bases and bots:
 
 ### Access Conversation Assist
 
-1. On the left sidebar in Conversational Cloud, click the <img style="width:30px" src="img/ConvoBuilder/icon_cb.png" alt=""> icon.
+1. On the left sidebar in Conversational Cloud, click the <img style="width:30px" alt="Bot icon" src="img/ConvoBuilder/icon_cb.png" alt=""> icon.
 2. In the [Conversational AI dashboard](platform-overview.html), click **Conversation Assist**.

--- a/pages/Documents/ConversationalAI/ConversationAssist/reports.md
+++ b/pages/Documents/ConversationalAI/ConversationAssist/reports.md
@@ -11,7 +11,7 @@ indicator: messaging
 
 Conversation Assist automatically generates a series of reports on the performance of your solution.
 
-<img class="fancyimage" style="width:800px" src="img/agentassist/reports1.png" alt="">
+<img class="fancyimage" style="width:800px" alt="List of reports" src="img/agentassist/reports1.png" alt="">
 
 The reports cover:
 
@@ -32,7 +32,7 @@ Overall, if you manage agent operations or you manage the recommendations from y
 1. [Access Conversation Assist](conversation-assist-overview.html#access-conversation-assist), and click **Reports** from the menu at the top.
 2. Use the filters on the left to display the reports you want.
 
-    <img class="fancyimage" style="width:300px" src="img/agentassist/reports2.png" alt="">
+    <img class="fancyimage" style="width:300px" alt="Filter options" src="img/agentassist/reports2.png" alt="">
 
 3. Do either of the following:
     * To download a single report, click its **Download** link.

--- a/pages/Documents/ConversationalAI/ConversationAssist/testing.md
+++ b/pages/Documents/ConversationalAI/ConversationAssist/testing.md
@@ -10,9 +10,10 @@ permalink: conversation-assist-testing.html
 indicator: messaging
 ---
 
-**Tip:** Before testing recommendations, verify that your bots and knowledge bases work in isolation.
+### Tip
+Before testing recommendations, verify that your bots and knowledge bases work in isolation.
 
-**To test recommendations**
+### Test recommendations
 
 1. Create a test skill, and assign it to your bot and/or knowledge base.
 2. [Start a new messaging conversation](https://developers.liveperson.io/web-messaging/) from the consumer side.
@@ -23,11 +24,11 @@ indicator: messaging
 
     In this example below, the consumer is asking about canceling an order.
 
-    <img width="550" src="img/agentassist/test1.png">
+    <img width="550" alt="Two recommendations being offered inline in the conversation" src="img/agentassist/test1.png">
 
 5. Click a recommendation to expand the box and view more information about it.
 
-    <img width="550" src="img/agentassist/test2.png">
+    <img width="550" alt="The expanded view of offered recommendations, which shows more details" src="img/agentassist/test2.png">
 
 6. Test [using the recommendations](conversation-assist-agent-experience.html), i.e., use the bot or the article.
 

--- a/pages/Documents/ConversationalAI/ConversationAssist/troubleshooting.md
+++ b/pages/Documents/ConversationalAI/ConversationAssist/troubleshooting.md
@@ -27,12 +27,12 @@ The campaign must be of the Messaging conversation type. Recommendations aren’
 
 Also, the engagement must route to specific skills. It should not be set to route to all skills.
  
-<img width="500" src="img/agentassist/routing.png">
+<img width="500" alt="Route to specific skill setting" src="img/agentassist/routing.png">
 
 If you instead set the engagement to route to “All skills,” the effect is that conversations within the engagement don’t have an assigned skill. As a result, there are no recommendations within the Conversational Cloud agent workspace since all recommendations are made based on the conversation’s skills.
 
 ### Bots
-* You must use a supported bot provider, as described [here](conversation-assist-recommendation-sources-setting-up-bots.html#supported-bot-types).
+* You must use a [supported bot provider](conversation-assist-recommendation-sources-setting-up-bots.html#supported-bot-types).
 * The bot must be able to join a conversation, i.e., there is an assigned bot user that is online and ready to accept conversations.
 * A Google Dialogflow bot with a particular region ID will only show in the messaging window for that region. Make sure your Dialogflow bot agents are set up in the appropriate region; otherwise, they won’t be offered as Conversation Assist recommendations for that region.
 


### PR DESCRIPTION
Misc. copyedits include replacing "here" links with other link labels and adding alt text to images within the Conversation Assist section of docs.