### PR TITLE
Key should be base64url encoded rather than base64

### DIFF
--- a/pages/Documents/Security&Authentication/ConsumerAuthentication/detailed-api.md
+++ b/pages/Documents/Security&Authentication/ConsumerAuthentication/detailed-api.md
@@ -282,7 +282,7 @@ Example for Mandatory+Standard+Custom Claims JWT:
 
 * The JWT should be signed with your RSA private key.
 
-* The public key should be base64 encoded with X509 key spec and can _either_ be provided by a JWKS endpoint or added to LivePerson OAuth configuration in the “JWT Public Key" field.  
+* The public key should be base64url encoded with X509 key spec and can _either_ be provided by a JWKS endpoint or added to LivePerson OAuth configuration in the “JWT Public Key" field.  
     **Note:** For more details on JWKS, please read [this (external) article](https://inthiraj1994.medium.com/signature-verification-using-jwks-endpoint-in-wso2-identity-server-5ba65c5de086#:~:text=The%20JSON%20Web%20Key%20Set,used%20to%20sign%20the%20tokens).
 
 ### Nested JWT


### PR DESCRIPTION
base64-encoded and base64url-encoded are different, we require the latter, and this error in the document has enraged our client RBC