### PR TITLE
Fix typo for history control api

### DIFF
--- a/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/ReleaseNotes/Regular/6.7.0.md
+++ b/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/ReleaseNotes/Regular/6.7.0.md
@@ -9,7 +9,7 @@ The iOS Mobile Messaging SDK version 6.7.0.820 is supported on iOS versions 13 t
 
 **This XCFramework was compiled with Swift version Apple Swift version 5.2.4 (swiftlang-1103.0.32.9 clang-1103.0.32.53) which means it will work Swift version 5.2.4 and above.**
 
-{: .attn-alert}
+{: .notice}
 XCFramework is supported on CocoaPad versions 1.9.0 and greater.
 
 #### Bugs fixed
@@ -31,7 +31,7 @@ SDK will have the capability of clearing the welcome message as well including t
 When using the Control History API, conversations are filtered in real time based on the parameters provided, once each conversation dialog is closed the Conversation Screen will reflect the changes accordingly.
 
 {: .warning}
-To enable displaying the Welcome Message when using this feature, enable the following configuration `enableWelcomeMessageForHistoryControlAPI`, this is only supported when setting `LPConversationsHistoryStateToDisplay.Open`. To see more about how to achieve this visit [link]()
+To enable displaying the Welcome Message when using this feature, enable the following configuration `enableWelcomeMessageForControlHistoryAPI`, this is only supported when setting `LPConversationsHistoryStateToDisplay.Open`. To see more about how to achieve this visit [link]()
 
 #### New configurations
 
@@ -43,7 +43,7 @@ To enable displaying the Welcome Message when using this feature, enable the fol
 - **See also:** [Clear History Function](mobile-app-messaging-sdk-for-ios-sdk-apis-messaging-api.html#clearhistory)
 - **Limitations:** The history is still available both on the Server and Local Database, and will be loaded next time the Conversation Screen is presented.
  
-##### enableWelcomeMessageForHistoryControlAPI
+##### enableWelcomeMessageForControlHistoryAPI
 - **Description:** This configuration will only enable showing the Welcome Message when `LPConversationsHistoryStateToDisplay.Open`
 - **Type:** Bool
 - **Default Value:** false

--- a/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/SDKAPIs/control-history-apis.md
+++ b/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/SDKAPIs/control-history-apis.md
@@ -30,7 +30,7 @@ The APIs lets brands:
 
 - When opening the window with closed conversations only, the window opens as a view only mode.
 
-- To enable the presentation of the Welcome Message, the following configuration needs to be set to true: `enableWelcomeMessageForHistoryControlAPI`
+- To enable the presentation of the Welcome Message, the following configuration needs to be set to true: `enableWelcomeMessageForControlHistoryAPI`
 
 {: .attn-note}
 To see more about the Welcome Message with Quick Replies, visit the following [page](mobile-app-messaging-sdk-for-ios-advanced-features-welcome-message-with-quick-replies.html).

--- a/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/SDKAPIs/control-history-apis.md
+++ b/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/SDKAPIs/control-history-apis.md
@@ -113,7 +113,7 @@ Used to decide whether to count the days from the conversation start date or end
 ```swift
  func showConversation() {
     // Configuration needs to be set to true to present Welcome Message if one is configured
-    LPConfig.defaultConfiguration.enableWelcomeMessageForHistoryControlAPI = true
+    LPConfig.defaultConfiguration.enableWelcomeMessageForControlHistoryAPI = true
 
     // Welcome Message Configuration
 

--- a/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/SDKAttributes/branding-and-configurations.md
+++ b/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/SDKAttributes/branding-and-configurations.md
@@ -491,7 +491,7 @@ The configuration to control our modal presentation stylen for LPDatePicker cont
 - **See also:** [Clear History Function](mobile-app-messaging-sdk-for-ios-sdk-apis-messaging-api.html#clearhistory)
 - **Limitations:** The history is still available both on the Server and Local Database, and will be loaded next time the Conversation Screen is presented.
 
-##### enableWelcomeMessageForHistoryControlAPI
+##### enableWelcomeMessageForControlHistoryAPI
 - **Description:** This configuration will only enable showing the Welcome Message when `LPConversationsHistoryStateToDisplay.Open`
 - **Type:** Bool
 - **Default Value:** false


### PR DESCRIPTION
fixed typo from enableWelcomeMessageForHistoryControlAPI to enableWelcomeMessageForControlHistoryAPI in 3 instances