### PR TITLE
refactor: obsolete and replace “warning” classes

### DIFF
--- a/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/ReleaseNotes/Regular/6.6.0.md
+++ b/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/ReleaseNotes/Regular/6.6.0.md
@@ -19,7 +19,7 @@ XCFramework is supported on CocoaPad versions 1.9.0 and greater.
 **Description:**
 Enabling Brands to leverage new JSON schema containing appointmentList Action, presenting new UI components on the Conversation Screen allowing to self-serve appointment selections.
 
-{: .warning}
+{: .attn-note}
 Appointment List JSON schema is only supported on accounts using UMS version 4.2, please contact your LivePerson representative to validate your account qualifies for this feature.
 
 #### Bugs fixed

--- a/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/ReleaseNotes/Regular/6.7.0.md
+++ b/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/ReleaseNotes/Regular/6.7.0.md
@@ -30,7 +30,7 @@ SDK will have the capability of clearing the welcome message as well including t
 
 When using the Control History API, conversations are filtered in real time based on the parameters provided, once each conversation dialog is closed the Conversation Screen will reflect the changes accordingly.
 
-{: .attn-alert}
+{: .attn-note}
 To enable displaying the Welcome Message when using this feature, enable the following configuration `enableWelcomeMessageForControlHistoryAPI`, this is only supported when setting `LPConversationsHistoryStateToDisplay.Open`. To see more about how to achieve this visit [link]()
 
 #### New configurations


### PR DESCRIPTION
(Successor for #1931)