### PR TITLE
reworded free trial link to reflect demo as requested

### DIFF
--- a/pages/Documents/GettingStarted/getting-started-with-your-free-trial-account.md
+++ b/pages/Documents/GettingStarted/getting-started-with-your-free-trial-account.md
@@ -30,17 +30,17 @@ indicator: both
       </div>
    </div>
 </div>
-<div class="welcome-card-modified">
+<!-- <div class="welcome-card-modified">
    <div class="small-header">
       About your Free Trial Account
    </div>
    <div class="convo-cloud-paragraph">
       Your 45-day trial account comes pre-loaded with a Concierge Bot to help you quickly make the most of our conversational AI platform. Learn more about your Concierge Bot <a href="/starting-with-your-concierge-bot.html">here</a>.
    </div>
-</div>
+</div>-->
 <div>
    <div class="attn-note" style="width:90%">
-      <b>Prerequisites</b> if you don’t already have a Conversational Cloud account, <a href="https://developers.liveperson.com/register.html">register</a> for a free 45-day trial.
+      <b>Prerequisites</b> If you don't already have a Conversational Cloud account, <a href="https://developers.liveperson.com/register.html">request</a> a LivePerson demo.
    </div>
 </div>
 <div class="concierge-bot-header">


### PR DESCRIPTION
Removed traces of "free trial" from the article as requested and re-worded according to the demo landing page.